### PR TITLE
Fix for guild name display

### DIFF
--- a/Altoholic_Summary/AccountSummary.lua
+++ b/Altoholic_Summary/AccountSummary.lua
@@ -1332,7 +1332,8 @@ columns["GuildName"] = {
 	Width = 120,
 	JustifyH = "CENTER",
 	GetText = function(character) 
-		local guildName, guildRank = DataStore:GetGuildInfo(character)
+		local guildName = DataStore:GetGuildName(character)
+		local guildRank = DataStore:GetGuildInfo(character, DataStore:GetCharacterGuildID(character))
 		
 		if Altoholic_SummaryTab_Options.ShowGuildRank then
 			return FormatGreyIfEmpty(guildRank)


### PR DESCRIPTION
Made two calls to DataStore functions (GetGuildName and GetGuildInfo) to get the name and rank since GetGuildInfo doesn't return the guild name.